### PR TITLE
Fix #2, remove chunking from server side render

### DIFF
--- a/app/routes/About/index.js
+++ b/app/routes/About/index.js
@@ -1,7 +1,12 @@
 module.exports = {
 	path: 'about',
 	getComponent(nextState, cb) {
-		System.import('./components/About.jsx')
-			.then((About) => cb(null, About));
+        if (ONSERVER) {
+            // Don't code split w/ System.import for server side render
+            cb(null, requre('./components/About.jsx'));
+        } else {
+            System.import('./components/About.jsx')
+                .then((About) => cb(null, About));
+        }
 	}
 }

--- a/app/routes/Complex/index.jsx
+++ b/app/routes/Complex/index.jsx
@@ -2,23 +2,39 @@ module.exports = {
 	path: 'complex',
 	
 	getChildRoutes(partialNextState, cb) {
-		require.ensure([], (require) => {
+        if (ONSERVER) {
 			cb(null, [
 				require('./routes/Page1'),
 				require('./routes/Page2')
 			])
-		})
+        } else {
+            require.ensure([], (require) => {
+                cb(null, [
+                    require('./routes/Page1'),
+                    require('./routes/Page2')
+                ])
+            })
+        }
 	},
 	getIndexRoute(partialNextState, cb) {
-		require.ensure([], (require) => {
-			// separate out the path part, otherwise warning raised
+        if (ONSERVER) {
 			const { path, getComponent } = require('./routes/Page1');
 			cb(null, { getComponent });
-		})
+        } else {
+            require.ensure([], (require) => {
+                // separate out the path part, otherwise warning raised
+                const { path, getComponent } = require('./routes/Page1');
+                cb(null, { getComponent });
+            })
+        }
 	},
 	getComponent(nextState, cb) {
-		require.ensure([], (require) => {
-			cb(null, require('./components/Complex.jsx'))
-		})
+        if (ONSERVER) {
+            cb(null, require('./components/Complex.jsx'));
+        } else {
+            require.ensure([], (require) => {
+                cb(null, require('./components/Complex.jsx'))
+            })
+        }
 	}
 }

--- a/app/routes/Home/index.js
+++ b/app/routes/Home/index.js
@@ -1,7 +1,11 @@
 module.exports = {
 	path: 'home',
 	getComponent(nextState, cb) {
-		System.import('./components/Home.jsx')
-			.then((Home) => cb(null, Home));
+        if (ONSERVER) {
+            cb(null, require('./components/Home.jsx'));
+        } else {
+            System.import('./components/Home.jsx')
+                .then((Home) => cb(null, Home));
+        }
 	}
 }

--- a/webpack.client.config.js
+++ b/webpack.client.config.js
@@ -41,6 +41,12 @@ module.exports = {
 		}]
 	},
 	plugins: [
+		new webpack.DefinePlugin({
+            // http://stackoverflow.com/a/35372706/2177568
+            // for server side code, just require, don't chunk
+            // use `if (ONSERVER) { ...` for server specific code
+            ONSERVER: false
+        }),
 		new FaviconsWebpackPlugin({
 			logo: './app/images/favicon.png',
 			prefix: 'icons-[hash]/',
@@ -72,13 +78,13 @@ module.exports = {
 			filename: 'style.css',
 			allChunks: true
 		}),
-                new webpack.LoaderOptionsPlugin({
-                    options: {
-                        sassLoader: {
-                                includePaths: [path.resolve(__dirname, "./node_modules/compass-mixins/lib")]
-                        }
-                    }
-                })
+        new webpack.LoaderOptionsPlugin({
+            options: {
+                sassLoader: {
+                    includePaths: [path.resolve(__dirname, "./node_modules/compass-mixins/lib")]
+                }
+            }
+        })
 	],
 	devServer: {
 		historyApiFallback: true,

--- a/webpack.server.config.js
+++ b/webpack.server.config.js
@@ -35,13 +35,18 @@ module.exports = {
                 }]
 	},
 	plugins: [
-		//new webpack.DefinePlugin({"process.env": {NODE_ENV: '"production"'}})
-                new webpack.LoaderOptionsPlugin({
-                    options: {
-                        sassLoader: {
-                                includePaths: [path.resolve(__dirname, "./node_modules/compass-mixins/lib")]
-                        }
-                    }
-                })
+		new webpack.DefinePlugin({
+            // http://stackoverflow.com/a/35372706/2177568
+            // for server side code, just require, don't chunk
+            // use `if (ONSERVER) { ...` for server specific code
+            ONSERVER: true
+        }),
+        new webpack.LoaderOptionsPlugin({
+            options: {
+                sassLoader: {
+                    includePaths: [path.resolve(__dirname, "./node_modules/compass-mixins/lib")]
+                }
+            }
+        })
 	],
 }


### PR DESCRIPTION
The server environment doesn't resolve `System.import` or `require.ensure` imports, so if they are left as they are on the client code, nothing shows up where they should be in the `renderToString()` return (in `server.js`). 

To fix this, I've defined a constant `ONSERVER` in the `webpack.server.config.js` and `webpack.client.config.js` which is set to true for the server. Then, in the routing definitions, we branch and use just `require` for the server side, and `System.import` or `require.ensure` for the client code. 

